### PR TITLE
feat: create TCP direct outbound component (#3)

### DIFF
--- a/src/core/transport/endpoint/actor.rs
+++ b/src/core/transport/endpoint/actor.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::RwLock};
 use error_stack::{IntoReport, Report, ResultExt};
 use tokio::{
     sync::{mpsc, oneshot},
-    task::JoinHandle,
+    task::{JoinHandle, JoinSet},
 };
 
 use crate::{
@@ -163,9 +163,12 @@ impl QuicEndpointActor {
         )
     }
 
-    async fn handle_connect(&self, msg: ConnectMsg) {
-        let result = self.endpoint.connect(&msg.service).await;
-        let _ = msg.reply.send(result);
+    fn handle_connect(&self, msg: ConnectMsg, connect_tasks: &mut JoinSet<()>) {
+        let endpoint = self.endpoint.clone();
+        connect_tasks.spawn(async move {
+            let result = endpoint.connect(&msg.service).await;
+            let _ = msg.reply.send(result);
+        });
     }
 
     fn cleanup_stale(&mut self) {
@@ -228,10 +231,12 @@ impl QuicEndpointActor {
         mut connect_rx: mpsc::Receiver<ConnectMsg>,
         mut publish_rx: mpsc::Receiver<PublishMsg>,
     ) {
+        let mut connect_tasks = JoinSet::new();
+
         loop {
             tokio::select! {
                 Some(msg) = connect_rx.recv() => {
-                    self.handle_connect(msg).await;
+                    self.handle_connect(msg, &mut connect_tasks);
                 },
                 Some(msg) = publish_rx.recv() => {
                     self.handle_publish(msg);
@@ -243,6 +248,11 @@ impl QuicEndpointActor {
                     None => {
                         log::debug!("QuicEndpointActor: endpoint is closed, shutting down");
                         break;
+                    }
+                },
+                Some(result) = connect_tasks.join_next() => {
+                    if let Err(e) = result {
+                        log::debug!("QuicEndpointActor: connect task failed: {e:?}");
                     }
                 },
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,17 @@ pub struct Socks5Addr(pub SocketAddr);
 pub struct TcpDirectTargets(pub HashMap<String, SocketAddr>);
 
 /// Fundle DI container for the entire application configuration.
-///
-/// - `endpoint_addr`: UDP address to bind the QUIC endpoint to.
-/// - `addr_map`: maps service names to their remote UDP addresses.
-/// - `socks5_addr`: if present, the local address to bind the SOCKS5 listener to.
 #[fundle::bundle]
 pub struct AppConfigBundle {
+    /// The UDP address to bind the QUIC endpoint to.
     pub endpoint_addr: EndpointAddr,
+
+    /// A mapping of service names to their remote UDP addresses.
     pub addr_map: AddrMap,
+
+    /// If present, the local address to bind the SOCKS5 inbound listener to.
     pub socks5_addr: Option<Socks5Addr>,
+
+    /// A mapping of service names to their remote TCP addresses for TCP direct outbound.
     pub tcp_direct_targets: TcpDirectTargets,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub struct AddrMap(pub HashMap<String, SocketAddr>);
 #[derive(Debug, Clone)]
 pub struct Socks5Addr(pub SocketAddr);
 
+#[derive(Debug, Clone)]
+pub struct TcpDirectTargets(pub HashMap<String, SocketAddr>);
+
 /// Fundle DI container for the entire application configuration.
 ///
 /// - `endpoint_addr`: UDP address to bind the QUIC endpoint to.
@@ -28,4 +31,5 @@ pub struct AppConfigBundle {
     pub endpoint_addr: EndpointAddr,
     pub addr_map: AddrMap,
     pub socks5_addr: Option<Socks5Addr>,
+    pub tcp_direct_targets: TcpDirectTargets,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,20 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 use error_stack::{Report, ResultExt};
 
 use flor::{
-    AddrMap, AppConfigBundle, EndpointAddr, Socks5Addr,
+    AddrMap, AppConfigBundle, EndpointAddr, Socks5Addr, TcpDirectTargets,
     cli::{print_error, write_secret},
     core::{
         identity::{Kind, TrustDomain, build_id, keygen_csr},
         transport::{
-            QuicConnector, TransportBundle,
+            QuicConnector, QuicPublisher, TransportBundle,
             endpoint::connection::{Accept, Open},
         },
     },
     logging,
-    northbound::inbound::{Error as InboundError, InboundBundle},
+    northbound::{
+        inbound::{Error as InboundError, InboundBundle},
+        outbound::{Error as OutboundError, OutboundBundle},
+    },
     utils::report::ErrorReport,
 };
 
@@ -45,8 +48,8 @@ enum Cmd {
     },
     /// Run the demo (legacy, replaced by `agent run` once the daemon lands).
     Demo {
-        /// Select node config: Alpha, Beta, or Gamma
-        #[arg(long, default_value = "Alpha", value_parser = ["Alpha", "Beta", "Gamma"])]
+        /// Select node config: Alpha, Beta, Gamma, or Delta
+        #[arg(long, default_value = "Alpha", value_parser = ["Alpha", "Beta", "Gamma", "Delta"])]
         name: String,
     },
 }
@@ -81,11 +84,12 @@ struct KeygenArgs {
 
 #[fundle::bundle]
 struct AppBundle {
-    #[forward(EndpointAddr, AddrMap, Option<Socks5Addr>)]
+    #[forward(EndpointAddr, AddrMap, Option<Socks5Addr>, TcpDirectTargets)]
     pub config: AppConfigBundle,
-    #[forward(QuicConnector)]
+    #[forward(QuicConnector, QuicPublisher)]
     pub transport: TransportBundle,
     pub inbound: InboundBundle,
+    pub outbound: OutboundBundle,
 }
 
 fn main() {
@@ -139,15 +143,17 @@ fn run_demo(node_name: String) -> Result<(), Report<Error>> {
 }
 
 async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
-    // Initial version uses workload names instead of identities.
-    // Node configuration: (quic_addr, served_workloads, socks5_addr)
+    // Initial demo services use workload names; TCP direct services use DNS-style names.
+    // The transport currently uses service names directly as QUIC TLS SNI values.
+    // Node configuration: (quic_addr, demo_served_workloads, socks5_addr, tcp_direct_targets)
     let service_map = HashMap::from([
         (
             "Alpha",
             (
                 "127.0.0.1:31337".parse::<SocketAddr>().unwrap(),
-                vec!["alice"],
+                vec!["alice", "eve"],
                 Some("127.0.0.1:1080".parse::<SocketAddr>().unwrap()),
+                HashMap::new(),
             ),
         ),
         (
@@ -156,6 +162,7 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
                 "127.0.0.1:31338".parse::<SocketAddr>().unwrap(),
                 vec!["bob"],
                 None,
+                HashMap::new(),
             ),
         ),
         (
@@ -164,14 +171,31 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
                 "127.0.0.1:31339".parse::<SocketAddr>().unwrap(),
                 vec!["carol"],
                 None,
+                HashMap::new(),
+            ),
+        ),
+        (
+            "Delta",
+            (
+                "127.0.0.1:31440".parse::<SocketAddr>().unwrap(),
+                vec![],
+                None,
+                HashMap::from([(
+                    "tcp-echo.demo.flor.local".to_string(),
+                    "127.0.0.1:32440".parse::<SocketAddr>().unwrap(),
+                )]),
             ),
         ),
     ]);
     // Directed workload connections: (client, server)
-    let conn_list = vec![("alice", "bob"), ("carol", "bob")];
+    let conn_list = vec![
+        ("alice", "bob"),
+        ("carol", "bob"),
+        ("eve", "tcp-echo.demo.flor.local"),
+    ];
 
     // Get current node config
-    let (local_addr, served, socks5_addr) = service_map
+    let (local_addr, served, socks5_addr, tcp_direct_targets) = service_map
         .get(node_name.as_str())
         .ok_or_else(|| Report::new(Error("Node not found in predefined service map".into())))?;
 
@@ -185,11 +209,11 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
     // For each service a node hosts, emit (service_name, node_addr)
     let addr_map: HashMap<String, SocketAddr> = service_map
         .iter()
-        .flat_map(|(_node, (addr, services, _socks5))| {
-            services
-                .iter()
-                .map(move |svc| (svc.to_string(), *addr))
-                .collect::<Vec<_>>()
+        .flat_map(|(_node, (addr, services, _socks5, tcp_targets))| {
+            let demo_services = services.iter().map(move |svc| (svc.to_string(), *addr));
+            let tcp_direct_services = tcp_targets.keys().map(move |svc| (svc.to_string(), *addr));
+
+            demo_services.chain(tcp_direct_services).collect::<Vec<_>>()
         })
         .collect();
 
@@ -201,25 +225,33 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
             endpoint_addr: EndpointAddr(*local_addr),
             addr_map: AddrMap(addr_map.clone()),
             socks5_addr: socks5_addr.map(Socks5Addr),
+            tcp_direct_targets: TcpDirectTargets(tcp_direct_targets.clone()),
         })
         .transport_try(|b| TransportBundle::try_new(b))
         .change_context_lazy(bundle_err)?
         .inbound_try_async(init_inbound)
         .await
         .change_context_lazy(bundle_err)?
+        .outbound_try_async(init_outbound)
+        .await
+        .change_context_lazy(bundle_err)?
         .build();
 
-    let mut acceptor = app
-        .transport
-        .endpoint_publisher
-        .publish(served_names.clone())
-        .await
-        .change_context(Error("Failed to publish served services".into()))?;
-    let acceptor_handle = tokio::spawn(async move {
-        while let Some((service_name, conn)) = acceptor.accept().await {
-            tokio::spawn(handle_connection(service_name, conn));
-        }
-    });
+    let acceptor_handle = if served_names.is_empty() {
+        None
+    } else {
+        let mut acceptor = app
+            .transport
+            .endpoint_publisher
+            .publish(served_names.clone())
+            .await
+            .change_context(Error("Failed to publish served services".into()))?;
+        Some(tokio::spawn(async move {
+            while let Some((service_name, conn)) = acceptor.accept().await {
+                tokio::spawn(handle_connection(service_name, conn));
+            }
+        }))
+    };
 
     // Fire-and-forget client connections; server keeps the process alive
     for (src, dst) in &conn_list {
@@ -237,9 +269,15 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
 
     let endpoint_handle = app.transport.endpoint_handle;
     let socks5_handle = app.inbound.socks5_handle;
+    let tcp_direct_handle = app.outbound.tcp_direct_handle;
 
     tokio::select! {
-        result = acceptor_handle => {
+        result = async {
+            match acceptor_handle {
+                Some(h) => h.await,
+                None => std::future::pending().await,
+            }
+        } => {
             if let Err(e) = result {
                 log::error!("Acceptor task failed: {e:?}");
             }
@@ -257,6 +295,16 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
         } => {
             if let Err(e) = result {
                 log::error!("Socks5 task failed: {e:?}");
+            }
+        }
+        result = async {
+            match tcp_direct_handle {
+                Some(h) => h.wait().await,
+                None => std::future::pending().await,
+            }
+        } => {
+            if let Err(e) = result {
+                log::error!("TCP direct outbound task failed: {e:?}");
             }
         }
     }
@@ -363,7 +411,14 @@ async fn initiate_connection(
 
 // Workaround to avoid rust-analyzer issue with async closures.
 async fn init_inbound(
-    b: &AppBundleBuilder<fundle::Read, fundle::Set, fundle::Set, fundle::NotSet>,
+    b: &AppBundleBuilder<fundle::Read, fundle::Set, fundle::Set, fundle::NotSet, fundle::NotSet>,
 ) -> Result<InboundBundle, ErrorReport<InboundError>> {
     InboundBundle::try_new(b).await
+}
+
+// Workaround to avoid rust-analyzer issue with async closures.
+async fn init_outbound(
+    b: &AppBundleBuilder<fundle::Read, fundle::Set, fundle::Set, fundle::Set, fundle::NotSet>,
+) -> Result<OutboundBundle, ErrorReport<OutboundError>> {
+    OutboundBundle::try_new(b).await
 }

--- a/src/northbound.rs
+++ b/src/northbound.rs
@@ -2,3 +2,4 @@
 // Licensed under Apache-2.0 or MIT at your option.
 
 pub mod inbound;
+pub mod outbound;

--- a/src/northbound/outbound.rs
+++ b/src/northbound/outbound.rs
@@ -1,11 +1,16 @@
 // Copyright (C) 2026 ReteLabs LLC.
 // Licensed under Apache-2.0 or MIT at your option.
 
-use error_stack::ResultExt;
+use async_trait::async_trait;
+use error_stack::{Report, ResultExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::{
     TcpDirectTargets,
-    core::transport::QuicPublisher,
+    core::transport::{
+        QuicPublisher,
+        endpoint::connection::{Accept, QuicConnection},
+    },
     northbound::outbound::tcp::{TcpDirectHandle, TcpDirectOutbound},
     utils::report::ErrorReport,
 };
@@ -15,6 +20,26 @@ pub mod tcp;
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct Error(String);
+
+trait QuicStream: AsyncRead + AsyncWrite + Unpin + Send {}
+
+impl<T> QuicStream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+#[async_trait]
+trait QuicInboundConnection: Send + Sync {
+    async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>>;
+}
+
+#[async_trait]
+impl QuicInboundConnection for QuicConnection {
+    async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>> {
+        let (send, recv) = self
+            .accept_bi()
+            .await
+            .change_context(Error("QUIC stream accept failed".into()))?;
+        Ok(Box::new(tokio::io::join(recv, send)))
+    }
+}
 
 /// Dependencies required to construct an [`OutboundBundle`].
 #[fundle::deps]
@@ -48,18 +73,13 @@ async fn init_tcp_direct(
         return Ok(None);
     }
 
-    let services = deps
-        .tcp_direct_targets
-        .0
-        .keys()
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(", ");
-    let tcp_direct = TcpDirectOutbound::new(deps.tcp_direct_targets.0, deps.quic_publisher)
+    let tcp_direct = TcpDirectOutbound::new(deps.tcp_direct_targets.0.clone(), deps.quic_publisher)
         .await
         .change_context(Error("Failed to create TCP direct outbound".into()))?
         .spawn();
 
-    log::info!("TCP direct outbound serving: {services}");
+    for (service_name, addr) in &deps.tcp_direct_targets.0 {
+        log::info!("TCP direct outbound serving '{service_name}' on '{addr}'");
+    }
     Ok(Some(tcp_direct))
 }

--- a/src/northbound/outbound.rs
+++ b/src/northbound/outbound.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 ReteLabs LLC.
+// Licensed under Apache-2.0 or MIT at your option.
+
+use error_stack::ResultExt;
+
+use crate::{
+    TcpDirectTargets,
+    core::transport::QuicPublisher,
+    northbound::outbound::tcp::{TcpDirectHandle, TcpDirectOutbound},
+    utils::report::ErrorReport,
+};
+
+pub mod tcp;
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct Error(String);
+
+/// Dependencies required to construct an [`OutboundBundle`].
+#[fundle::deps]
+pub struct OutboundDeps {
+    /// Service names served by this node and their TCP targets.
+    tcp_direct_targets: TcpDirectTargets,
+    /// QUIC publisher used by outbound handlers to subscribe to incoming sessions.
+    quic_publisher: QuicPublisher,
+}
+
+/// Fundle DI container for northbound outbound components.
+#[fundle::bundle]
+pub struct OutboundBundle {
+    pub tcp_direct_handle: Option<TcpDirectHandle>,
+}
+
+impl OutboundBundle {
+    /// Build the bundle from the given dependencies.
+    pub async fn try_new(deps: impl Into<OutboundDeps>) -> Result<Self, ErrorReport<Error>> {
+        let deps = deps.into();
+
+        let tcp_direct_handle = init_tcp_direct(deps).await?;
+        Ok(OutboundBundle { tcp_direct_handle })
+    }
+}
+
+async fn init_tcp_direct(
+    deps: OutboundDeps,
+) -> Result<Option<TcpDirectHandle>, ErrorReport<Error>> {
+    if deps.tcp_direct_targets.0.is_empty() {
+        return Ok(None);
+    }
+
+    let services = deps
+        .tcp_direct_targets
+        .0
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let tcp_direct = TcpDirectOutbound::new(deps.tcp_direct_targets.0, deps.quic_publisher)
+        .await
+        .change_context(Error("Failed to create TCP direct outbound".into()))?
+        .spawn();
+
+    log::info!("TCP direct outbound serving: {services}");
+    Ok(Some(tcp_direct))
+}

--- a/src/northbound/outbound/tcp.rs
+++ b/src/northbound/outbound/tcp.rs
@@ -1,0 +1,349 @@
+// Copyright (C) 2026 ReteLabs LLC.
+// Licensed under Apache-2.0 or MIT at your option.
+
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+
+use async_trait::async_trait;
+use error_stack::{Report, ResultExt};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+    task::{JoinHandle, JoinSet},
+};
+
+use crate::{
+    core::transport::{
+        QuicAcceptor, QuicPublisher,
+        endpoint::connection::{Accept, QuicConnection},
+    },
+    impl_lifecycle_handle,
+    utils::lifecycle::LifecycleHandle,
+};
+
+const LOG_TARGET: &str = "tcp_direct_outbound";
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct Error(String);
+
+trait QuicStream: AsyncRead + AsyncWrite + Unpin + Send {}
+
+impl<T> QuicStream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+#[async_trait]
+trait QuicInboundConnection: Send + Sync {
+    async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>>;
+}
+
+#[async_trait]
+impl QuicInboundConnection for QuicConnection {
+    async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>> {
+        let (send, recv) = self
+            .accept_bi()
+            .await
+            .change_context(Error("QUIC stream accept failed".into()))?;
+        Ok(Box::new(tokio::io::join(recv, send)))
+    }
+}
+
+/// Lifecycle handle for a running [`TcpDirectOutbound`].
+///
+/// Dropping this handle aborts the accept loop and all tracked in-flight
+/// connection tasks.
+pub struct TcpDirectHandle(LifecycleHandle);
+
+impl_lifecycle_handle!(TcpDirectHandle);
+
+/// TCP direct outbound component.
+///
+/// Subscribes to incoming QUIC connections for the configured service names and
+/// forwards every accepted bidirectional stream to the matching TCP address.
+pub struct TcpDirectOutbound {
+    acceptor: QuicAcceptor,
+    targets: Arc<HashMap<String, SocketAddr>>,
+}
+
+impl TcpDirectOutbound {
+    /// Publish the configured service names and return a component ready to start.
+    pub async fn new(
+        targets: HashMap<String, SocketAddr>,
+        publisher: QuicPublisher,
+    ) -> Result<Self, Report<Error>> {
+        let served = targets.keys().cloned().collect::<Vec<_>>();
+        let acceptor = publisher
+            .publish(served)
+            .await
+            .change_context(Error("Failed to publish TCP direct services".into()))?;
+
+        Ok(Self {
+            acceptor,
+            targets: Arc::new(targets),
+        })
+    }
+
+    /// Start the accept loop, returning a [`TcpDirectHandle`] that controls its lifetime.
+    pub fn spawn(self) -> TcpDirectHandle {
+        TcpDirectHandle::new(tokio::spawn(self.run()))
+    }
+
+    async fn run(mut self) {
+        let mut tasks = JoinSet::new();
+
+        loop {
+            tokio::select! {
+                accepted = self.acceptor.accept() => match accepted {
+                    Some((service_name, conn)) => {
+                        let targets = self.targets.clone();
+                        tasks.spawn(async move {
+                            handle_connection(service_name, conn, targets).await;
+                        });
+                    }
+                    None => {
+                        log::debug!(target: LOG_TARGET, "QUIC acceptor closed");
+                        break;
+                    }
+                },
+
+                Some(result) = tasks.join_next() => {
+                    if let Err(e) = result {
+                        log::warn!(target: LOG_TARGET, "Connection task failed: {e:?}");
+                    }
+                }
+            }
+        }
+        // Dropping JoinSet here aborts all in-flight connection tasks.
+    }
+}
+
+async fn handle_connection(
+    service_name: String,
+    conn: impl QuicInboundConnection + 'static,
+    targets: Arc<HashMap<String, SocketAddr>>,
+) {
+    let Some(target_addr) = targets.get(&service_name).copied() else {
+        log::debug!(target: LOG_TARGET, "No TCP target configured for '{service_name}'");
+        return;
+    };
+
+    let mut streams = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            stream = conn.accept_stream() => match stream {
+                Ok(stream) => {
+                    streams.spawn(relay_stream(service_name.clone(), target_addr, stream));
+                }
+                Err(e) => {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "QUIC connection closed for '{service_name}': {e:?}"
+                    );
+                    break;
+                }
+            },
+
+            Some(result) = streams.join_next() => {
+                if let Err(e) = result {
+                    log::debug!(target: LOG_TARGET,
+                        "Stream task failed for '{service_name}': {e:?}");
+                }
+            }
+        }
+    }
+    // Dropping JoinSet here aborts any streams still running on this connection.
+}
+
+async fn relay_stream(
+    service_name: String,
+    target_addr: SocketAddr,
+    mut quic_stream: Box<dyn QuicStream>,
+) {
+    let mut tcp_stream = match TcpStream::connect(target_addr).await {
+        Ok(stream) => stream,
+        Err(e) => {
+            log::debug!(
+                target: LOG_TARGET,
+                "Failed to connect TCP target {target_addr} for '{service_name}': {e:?}"
+            );
+            return;
+        }
+    };
+
+    match tokio::io::copy_bidirectional(&mut quic_stream, &mut tcp_stream).await {
+        Ok((quic_to_tcp, tcp_to_quic)) => {
+            log::trace!(
+                target: LOG_TARGET,
+                "Relayed '{service_name}' via {target_addr}: {quic_to_tcp} bytes QUIC->TCP, {tcp_to_quic} bytes TCP->QUIC"
+            );
+        }
+        Err(e) => {
+            log::debug!(
+                target: LOG_TARGET,
+                "Relay error for '{service_name}' via {target_addr}: {e:?}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, time::Duration};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::{Mutex, oneshot};
+
+    use super::*;
+
+    async fn bound_listener() -> (TcpListener, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        (listener, addr)
+    }
+
+    struct MockQuicConnection {
+        streams: Mutex<VecDeque<tokio::io::DuplexStream>>,
+    }
+
+    impl MockQuicConnection {
+        fn new(streams: Vec<tokio::io::DuplexStream>) -> Self {
+            Self {
+                streams: Mutex::new(streams.into()),
+            }
+        }
+    }
+
+    struct DropSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(tx) = self.0.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    async fn pending_handle_task() -> (TcpDirectHandle, oneshot::Receiver<()>) {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (dropped_tx, dropped_rx) = oneshot::channel();
+        let join = tokio::spawn(async move {
+            let _guard = DropSignal(Some(dropped_tx));
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        started_rx.await.expect("task should start");
+        (TcpDirectHandle::new(join), dropped_rx)
+    }
+
+    #[async_trait]
+    impl QuicInboundConnection for MockQuicConnection {
+        async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>> {
+            let stream = self.streams.lock().await.pop_front();
+            match stream {
+                Some(stream) => Ok(Box::new(stream)),
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stream_is_relayed_to_configured_tcp_target() {
+        let (listener, target_addr) = bound_listener().await;
+        let tcp_server = tokio::spawn(async move {
+            let (mut stream, _peer) = listener.accept().await.unwrap();
+
+            let mut buf = [0u8; 15];
+            stream.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf, b"hello from quic");
+
+            stream.write_all(b"hello from tcp").await.unwrap();
+        });
+
+        let (mut quic_peer, quic_component) = tokio::io::duplex(65536);
+        let conn = MockQuicConnection::new(vec![quic_component]);
+        let targets = Arc::new(HashMap::from([("service".to_string(), target_addr)]));
+        let handle = tokio::spawn(handle_connection("service".to_string(), conn, targets));
+
+        quic_peer.write_all(b"hello from quic").await.unwrap();
+
+        let mut buf = [0u8; 14];
+        tokio::time::timeout(Duration::from_secs(2), quic_peer.read_exact(&mut buf))
+            .await
+            .expect("timeout waiting for relayed TCP response")
+            .unwrap();
+        assert_eq!(&buf, b"hello from tcp");
+
+        tcp_server.await.unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_missing_service_target_does_not_connect_tcp() {
+        let (listener, target_addr) = bound_listener().await;
+        let tcp_server = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_millis(100), listener.accept()).await
+        });
+
+        let (_quic_peer, quic_component) = tokio::io::duplex(65536);
+        let conn = MockQuicConnection::new(vec![quic_component]);
+        let targets = Arc::new(HashMap::from([("other-service".to_string(), target_addr)]));
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            handle_connection("service".to_string(), conn, targets),
+        )
+        .await
+        .expect("handler should return when service is not configured");
+
+        assert!(tcp_server.await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_tcp_connect_failure_is_contained_to_stream() {
+        let (listener, target_addr) = bound_listener().await;
+        drop(listener);
+
+        let (mut quic_peer, quic_component) = tokio::io::duplex(65536);
+        let conn = MockQuicConnection::new(vec![quic_component]);
+        let targets = Arc::new(HashMap::from([("service".to_string(), target_addr)]));
+        let handle = tokio::spawn(handle_connection("service".to_string(), conn, targets));
+
+        quic_peer.write_all(b"hello").await.unwrap();
+        let mut buf = [0u8; 1];
+        let result =
+            tokio::time::timeout(Duration::from_millis(100), quic_peer.read(&mut buf)).await;
+        assert!(
+            result.is_err() || result.unwrap().unwrap() == 0,
+            "failed TCP connect should not produce response data"
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_handle_drop_aborts_task() {
+        let (handle, dropped_rx) = pending_handle_task().await;
+
+        drop(handle);
+
+        tokio::time::timeout(Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("handle drop should abort the task")
+            .expect("task should drop its guard");
+    }
+
+    #[tokio::test]
+    async fn test_handle_shutdown_aborts_and_waits_for_task() {
+        let (handle, dropped_rx) = pending_handle_task().await;
+
+        let result = handle.shutdown().await;
+
+        assert!(
+            result.is_err(),
+            "shutdown currently reports the aborted JoinError"
+        );
+        dropped_rx
+            .await
+            .expect("shutdown should wait until the task drops its guard");
+    }
+}

--- a/src/northbound/outbound/tcp.rs
+++ b/src/northbound/outbound/tcp.rs
@@ -3,20 +3,16 @@
 
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use async_trait::async_trait;
 use error_stack::{Report, ResultExt};
 use tokio::{
-    io::{AsyncRead, AsyncWrite},
     net::TcpStream,
     task::{JoinHandle, JoinSet},
 };
 
 use crate::{
-    core::transport::{
-        QuicAcceptor, QuicPublisher,
-        endpoint::connection::{Accept, QuicConnection},
-    },
+    core::transport::{QuicAcceptor, QuicPublisher},
     impl_lifecycle_handle,
+    northbound::outbound::{QuicInboundConnection, QuicStream},
     utils::lifecycle::LifecycleHandle,
 };
 
@@ -25,26 +21,6 @@ const LOG_TARGET: &str = "tcp_direct_outbound";
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct Error(String);
-
-trait QuicStream: AsyncRead + AsyncWrite + Unpin + Send {}
-
-impl<T> QuicStream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
-
-#[async_trait]
-trait QuicInboundConnection: Send + Sync {
-    async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>>;
-}
-
-#[async_trait]
-impl QuicInboundConnection for QuicConnection {
-    async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>> {
-        let (send, recv) = self
-            .accept_bi()
-            .await
-            .change_context(Error("QUIC stream accept failed".into()))?;
-        Ok(Box::new(tokio::io::join(recv, send)))
-    }
-}
 
 /// Lifecycle handle for a running [`TcpDirectOutbound`].
 ///
@@ -189,6 +165,8 @@ async fn relay_stream(
 mod tests {
     use std::{collections::VecDeque, time::Duration};
 
+    use async_trait::async_trait;
+    use error_stack::Report;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::{Mutex, oneshot};
@@ -237,7 +215,9 @@ mod tests {
 
     #[async_trait]
     impl QuicInboundConnection for MockQuicConnection {
-        async fn accept_stream(&self) -> Result<Box<dyn QuicStream>, Report<Error>> {
+        async fn accept_stream(
+            &self,
+        ) -> Result<Box<dyn QuicStream>, Report<crate::northbound::outbound::Error>> {
             let stream = self.streams.lock().await.pop_front();
             match stream {
                 Some(stream) => Ok(Box::new(stream)),


### PR DESCRIPTION
## How to test

1. Run `nc` utility: `nc -lk 127.0.0.1 32440`.
2. Run flor demo at Delta config: `cargo run --bin flor -- demo --name Delta`.
3. Run flor at Alpha config: `cargo run --bin flor -- demo --name Alpha`.
4. Wait for the message on the nc side: `Hello from eve`.

Refs: #3 