### PR TITLE
feat: configure flor vertex (#33)

### DIFF
--- a/src/core/transport.rs
+++ b/src/core/transport.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ReteLabs LLC.
 // Licensed under Apache-2.0 or MIT at your option.
 
-use std::sync::Arc;
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use error_stack::ResultExt;
 
@@ -14,7 +14,13 @@ mod insecure_server_verifier;
 pub use endpoint::{QuicAcceptor, QuicConnector, QuicHandle, QuicPublisher};
 pub use udp_resolver::UdpResolver;
 
-use crate::{AddrMap, EndpointAddr, utils::report::ErrorReport};
+use crate::utils::report::ErrorReport;
+
+#[derive(Debug, Clone)]
+pub struct EndpointAddr(pub SocketAddr);
+
+#[derive(Debug, Clone)]
+pub struct AddrMap(pub HashMap<String, SocketAddr>);
 
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub struct EndpointAddr(pub SocketAddr);
 pub struct AddrMap(pub HashMap<String, SocketAddr>);
 
 #[derive(Debug, Clone)]
-pub struct Socks5Addr(pub SocketAddr);
+pub struct Socks5Targets(pub HashMap<String, SocketAddr>);
 
 #[derive(Debug, Clone)]
 pub struct TcpDirectTargets(pub HashMap<String, SocketAddr>);
@@ -30,9 +30,9 @@ pub struct AppConfigBundle {
     /// A mapping of service names to their remote UDP addresses.
     pub addr_map: AddrMap,
 
-    /// If present, the local address to bind the SOCKS5 inbound listener to.
-    pub socks5_addr: Option<Socks5Addr>,
+    /// A mapping of client service names to local SOCKS5 inbound addresses.
+    pub socks5_targets: Socks5Targets,
 
-    /// A mapping of service names to their remote TCP addresses for TCP direct outbound.
+    /// A mapping of client service names to local TCP direct target addresses.
     pub tcp_direct_targets: TcpDirectTargets,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,14 @@
 // Copyright (C) 2026 ReteLabs LLC.
 // Licensed under Apache-2.0 or MIT at your option.
 
-use std::{collections::HashMap, net::SocketAddr};
-
 pub mod cli;
 pub mod core;
 pub mod logging;
 pub mod northbound;
 pub mod utils;
 
-#[derive(Debug, Clone)]
-pub struct EndpointAddr(pub SocketAddr);
-
-#[derive(Debug, Clone)]
-pub struct AddrMap(pub HashMap<String, SocketAddr>);
-
-#[derive(Debug, Clone)]
-pub struct Socks5Targets(pub HashMap<String, SocketAddr>);
-
-#[derive(Debug, Clone)]
-pub struct TcpDirectTargets(pub HashMap<String, SocketAddr>);
+use core::transport::{AddrMap, EndpointAddr};
+use northbound::{inbound::Socks5Bindings, outbound::TcpDirectBindings};
 
 /// Fundle DI container for the entire application configuration.
 #[fundle::bundle]
@@ -31,8 +20,8 @@ pub struct AppConfigBundle {
     pub addr_map: AddrMap,
 
     /// A mapping of client service names to local SOCKS5 inbound addresses.
-    pub socks5_targets: Socks5Targets,
+    pub socks5_bindings: Socks5Bindings,
 
-    /// A mapping of client service names to local TCP direct target addresses.
-    pub tcp_direct_targets: TcpDirectTargets,
+    /// A mapping of client service names to local TCP direct addresses.
+    pub tcp_direct_bindings: TcpDirectBindings,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 use error_stack::{Report, ResultExt};
 
 use flor::{
-    AddrMap, AppConfigBundle, EndpointAddr, Socks5Addr, TcpDirectTargets,
+    AddrMap, AppConfigBundle, EndpointAddr, Socks5Targets, TcpDirectTargets,
     cli::{print_error, write_secret},
     core::{
         identity::{Kind, TrustDomain, build_id, keygen_csr},
@@ -81,7 +81,7 @@ struct KeygenArgs {
 
 #[fundle::bundle]
 struct AppBundle {
-    #[forward(EndpointAddr, AddrMap, Option<Socks5Addr>, TcpDirectTargets)]
+    #[forward(EndpointAddr, AddrMap, Socks5Targets, TcpDirectTargets)]
     pub config: AppConfigBundle,
     #[forward(QuicConnector, QuicPublisher)]
     pub transport: TransportBundle,
@@ -148,8 +148,11 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
             "Alpha", // node name
             (
                 "127.0.0.1:31337".parse::<SocketAddr>().unwrap(), // QUIC address
-                vec![("alice", "127.0.0.1:1080".parse::<SocketAddr>().unwrap())], // SOCKS5 workloads
-                vec![], // TCP services (none on Alpha)
+                vec![
+                    ("alice", "127.0.0.1:1080".parse::<SocketAddr>().unwrap()),
+                    ("bob", "127.0.0.1:1081".parse::<SocketAddr>().unwrap()),
+                ], // SOCKS5 workloads
+                vec![],                                           // TCP services (none on Alpha)
             ),
         ),
         (
@@ -169,7 +172,10 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
     let (quic_addr, socks5_inbounds, tcp_outbounds) = service_map
         .get(node_name.as_str())
         .ok_or_else(|| Report::new(Error("Node not found in predefined service map".into())))?;
-    let socks5_addr = socks5_inbounds.first().map(|(_workload, addr)| *addr);
+    let socks5_targets = socks5_inbounds
+        .iter()
+        .map(|(workload, addr)| (workload.to_string(), *addr))
+        .collect::<HashMap<_, _>>();
     let tcp_direct_targets = tcp_outbounds.iter().cloned().collect::<HashMap<_, _>>();
 
     log::info!(
@@ -208,7 +214,7 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
         .config(|_| AppConfigBundle {
             endpoint_addr: EndpointAddr(*quic_addr),
             addr_map: AddrMap(addr_map.clone()),
-            socks5_addr: socks5_addr.map(Socks5Addr),
+            socks5_targets: Socks5Targets(socks5_targets.clone()),
             tcp_direct_targets: TcpDirectTargets(tcp_direct_targets.clone()),
         })
         .transport_try(|b| TransportBundle::try_new(b))

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,16 +7,16 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 use error_stack::{Report, ResultExt};
 
 use flor::{
-    AddrMap, AppConfigBundle, EndpointAddr, Socks5Targets, TcpDirectTargets,
+    AppConfigBundle,
     cli::{print_error, write_secret},
     core::{
         identity::{Kind, TrustDomain, build_id, keygen_csr},
-        transport::{QuicConnector, QuicPublisher, TransportBundle},
+        transport::{AddrMap, EndpointAddr, QuicConnector, QuicPublisher, TransportBundle},
     },
     logging,
     northbound::{
-        inbound::{Error as InboundError, InboundBundle},
-        outbound::{Error as OutboundError, OutboundBundle},
+        inbound::{Error as InboundError, InboundBundle, Socks5Bindings},
+        outbound::{Error as OutboundError, OutboundBundle, TcpDirectBindings},
     },
     utils::report::ErrorReport,
 };
@@ -81,7 +81,7 @@ struct KeygenArgs {
 
 #[fundle::bundle]
 struct AppBundle {
-    #[forward(EndpointAddr, AddrMap, Socks5Targets, TcpDirectTargets)]
+    #[forward(EndpointAddr, AddrMap, Socks5Bindings, TcpDirectBindings)]
     pub config: AppConfigBundle,
     #[forward(QuicConnector, QuicPublisher)]
     pub transport: TransportBundle,
@@ -172,11 +172,11 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
     let (quic_addr, socks5_inbounds, tcp_outbounds) = service_map
         .get(node_name.as_str())
         .ok_or_else(|| Report::new(Error("Node not found in predefined service map".into())))?;
-    let socks5_targets = socks5_inbounds
+    let socks5_bindings = socks5_inbounds
         .iter()
         .map(|(workload, addr)| (workload.to_string(), *addr))
         .collect::<HashMap<_, _>>();
-    let tcp_direct_targets = tcp_outbounds.iter().cloned().collect::<HashMap<_, _>>();
+    let tcp_direct_bindings = tcp_outbounds.iter().cloned().collect::<HashMap<_, _>>();
 
     log::info!(
         "Node '{}' bound to {}. SOCKS5 workloads: {}. TCP services: {}.",
@@ -214,8 +214,8 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
         .config(|_| AppConfigBundle {
             endpoint_addr: EndpointAddr(*quic_addr),
             addr_map: AddrMap(addr_map.clone()),
-            socks5_targets: Socks5Targets(socks5_targets.clone()),
-            tcp_direct_targets: TcpDirectTargets(tcp_direct_targets.clone()),
+            socks5_bindings: Socks5Bindings(socks5_bindings.clone()),
+            tcp_direct_bindings: TcpDirectBindings(tcp_direct_bindings.clone()),
         })
         .transport_try(|b| TransportBundle::try_new(b))
         .change_context_lazy(bundle_err)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,7 @@ use flor::{
     cli::{print_error, write_secret},
     core::{
         identity::{Kind, TrustDomain, build_id, keygen_csr},
-        transport::{
-            QuicConnector, QuicPublisher, TransportBundle,
-            endpoint::connection::{Accept, Open},
-        },
+        transport::{QuicConnector, QuicPublisher, TransportBundle},
     },
     logging,
     northbound::{
@@ -48,8 +45,8 @@ enum Cmd {
     },
     /// Run the demo (legacy, replaced by `agent run` once the daemon lands).
     Demo {
-        /// Select node config: Alpha, Beta, Gamma, or Delta
-        #[arg(long, default_value = "Alpha", value_parser = ["Alpha", "Beta", "Gamma", "Delta"])]
+        /// Select node config.
+        #[arg(long, default_value = "Alpha", value_parser = ["Alpha", "Beta"])]
         name: String,
     },
 }
@@ -145,84 +142,71 @@ fn run_demo(node_name: String) -> Result<(), Report<Error>> {
 async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
     // Initial demo services use workload names; TCP direct services use DNS-style names.
     // The transport currently uses service names directly as QUIC TLS SNI values.
-    // Node configuration: (quic_addr, demo_served_workloads, socks5_addr, tcp_direct_targets)
+    // Node configuration: (quic_addr, socks5_inbounds, tcp_direct_services)
     let service_map = HashMap::from([
         (
-            "Alpha",
+            "Alpha", // node name
             (
-                "127.0.0.1:31337".parse::<SocketAddr>().unwrap(),
-                vec!["alice", "eve"],
-                Some("127.0.0.1:1080".parse::<SocketAddr>().unwrap()),
-                HashMap::new(),
+                "127.0.0.1:31337".parse::<SocketAddr>().unwrap(), // QUIC address
+                vec![("alice", "127.0.0.1:1080".parse::<SocketAddr>().unwrap())], // SOCKS5 workloads
+                vec![], // TCP services (none on Alpha)
             ),
         ),
         (
-            "Beta",
+            "Beta", // node name
             (
-                "127.0.0.1:31338".parse::<SocketAddr>().unwrap(),
-                vec!["bob"],
-                None,
-                HashMap::new(),
-            ),
-        ),
-        (
-            "Gamma",
-            (
-                "127.0.0.1:31339".parse::<SocketAddr>().unwrap(),
-                vec!["carol"],
-                None,
-                HashMap::new(),
-            ),
-        ),
-        (
-            "Delta",
-            (
-                "127.0.0.1:31440".parse::<SocketAddr>().unwrap(),
-                vec![],
-                None,
-                HashMap::from([(
-                    "tcp-echo.demo.flor.local".to_string(),
-                    "127.0.0.1:32440".parse::<SocketAddr>().unwrap(),
-                )]),
+                "127.0.0.1:31440".parse::<SocketAddr>().unwrap(), // QUIC address
+                vec![],                                           // SOCKS5 workloads (none on Beta)
+                vec![(
+                    "tcp-echo.beta.demo-cluster.rete".to_string(),
+                    "127.0.0.1:32450".parse::<SocketAddr>().unwrap(),
+                )], // TCP services
             ),
         ),
     ]);
-    // Directed workload connections: (client, server)
-    let conn_list = vec![
-        ("alice", "bob"),
-        ("carol", "bob"),
-        ("eve", "tcp-echo.demo.flor.local"),
-    ];
 
     // Get current node config
-    let (local_addr, served, socks5_addr, tcp_direct_targets) = service_map
+    let (quic_addr, socks5_inbounds, tcp_outbounds) = service_map
         .get(node_name.as_str())
         .ok_or_else(|| Report::new(Error("Node not found in predefined service map".into())))?;
+    let socks5_addr = socks5_inbounds.first().map(|(_workload, addr)| *addr);
+    let tcp_direct_targets = tcp_outbounds.iter().cloned().collect::<HashMap<_, _>>();
 
     log::info!(
-        "Node '{}' bound to {} serving workloads: {}",
+        "Node '{}' bound to {}. SOCKS5 workloads: {}. TCP services: {}.",
         node_name,
-        local_addr,
-        served.join(", ")
+        quic_addr,
+        socks5_inbounds
+            .iter()
+            .map(|(workload, _addr)| *workload)
+            .collect::<Vec<_>>()
+            .join(", "),
+        tcp_outbounds
+            .iter()
+            .map(|(service, _target)| service.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
     );
 
-    // For each service a node hosts, emit (service_name, node_addr)
+    // For each workload or service a node hosts, emit (name, node_addr).
     let addr_map: HashMap<String, SocketAddr> = service_map
         .iter()
-        .flat_map(|(_node, (addr, services, _socks5, tcp_targets))| {
-            let demo_services = services.iter().map(move |svc| (svc.to_string(), *addr));
-            let tcp_direct_services = tcp_targets.keys().map(move |svc| (svc.to_string(), *addr));
+        .flat_map(|(_node, (addr, socks5_inbounds, tcp_outbounds))| {
+            let workloads = socks5_inbounds
+                .iter()
+                .map(move |(workload, _listen_addr)| (workload.to_string(), *addr));
+            let tcp_services = tcp_outbounds
+                .iter()
+                .map(move |(service, _target)| (service.clone(), *addr));
 
-            demo_services.chain(tcp_direct_services).collect::<Vec<_>>()
+            workloads.chain(tcp_services)
         })
         .collect();
-
-    let served_names: Vec<String> = served.iter().map(|s| s.to_string()).collect();
 
     let bundle_err = || Error("Failed to build app bundle".into());
     let app: AppBundle = AppBundle::builder()
         .config(|_| AppConfigBundle {
-            endpoint_addr: EndpointAddr(*local_addr),
+            endpoint_addr: EndpointAddr(*quic_addr),
             addr_map: AddrMap(addr_map.clone()),
             socks5_addr: socks5_addr.map(Socks5Addr),
             tcp_direct_targets: TcpDirectTargets(tcp_direct_targets.clone()),
@@ -237,51 +221,11 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
         .change_context_lazy(bundle_err)?
         .build();
 
-    let acceptor_handle = if served_names.is_empty() {
-        None
-    } else {
-        let mut acceptor = app
-            .transport
-            .endpoint_publisher
-            .publish(served_names.clone())
-            .await
-            .change_context(Error("Failed to publish served services".into()))?;
-        Some(tokio::spawn(async move {
-            while let Some((service_name, conn)) = acceptor.accept().await {
-                tokio::spawn(handle_connection(service_name, conn));
-            }
-        }))
-    };
-
-    // Fire-and-forget client connections; server keeps the process alive
-    for (src, dst) in &conn_list {
-        if served_names.contains(&src.to_string()) {
-            let connector = app.transport.endpoint_connector.clone();
-            let src = src.to_string();
-            let dst = dst.to_string();
-            tokio::spawn(async move {
-                if let Err(e) = initiate_connection(&connector, &src, &dst).await {
-                    log::error!("Connection {}=>{} failed: {:?}", src, dst, e);
-                }
-            });
-        }
-    }
-
     let endpoint_handle = app.transport.endpoint_handle;
     let socks5_handle = app.inbound.socks5_handle;
     let tcp_direct_handle = app.outbound.tcp_direct_handle;
 
     tokio::select! {
-        result = async {
-            match acceptor_handle {
-                Some(h) => h.await,
-                None => std::future::pending().await,
-            }
-        } => {
-            if let Err(e) = result {
-                log::error!("Acceptor task failed: {e:?}");
-            }
-        }
         result = endpoint_handle.wait() => {
             if let Err(e) = result {
                 log::error!("Endpoint actor task failed: {e:?}");
@@ -309,103 +253,6 @@ async fn demo_main(node_name: String) -> Result<(), Report<Error>> {
         }
     }
 
-    Ok(())
-}
-
-async fn handle_connection<C: Accept>(service_name: String, conn: C) {
-    loop {
-        // Accept a new bidirectional stream
-        let stream = match conn.accept_bi().await {
-            Ok(s) => s,
-            Err(e) => {
-                // Connection closed or error: exit the loop
-                log::debug!("Stream accept error for {}: {:?}", service_name, e);
-                break;
-            }
-        };
-
-        let (mut send, mut recv) = stream;
-        let mut buf = vec![0u8; 1024];
-
-        match recv.read(&mut buf).await {
-            Ok(Some(n)) => {
-                // Successfully read n bytes
-                let msg = String::from_utf8_lossy(&buf[..n]);
-                log::info!("< [{}] {}", service_name, msg);
-
-                let reply = format!("{} reporting!", service_name);
-                if let Err(e) = send.write_all(reply.as_bytes()).await {
-                    log::warn!("Failed to send reply to {}: {:?}", service_name, e);
-                    // Continue: connection may still be usable for other streams
-                } else {
-                    log::info!("> [{}] {}", service_name, reply);
-                }
-
-                // Signal that we're done sending on this stream
-                // Client may still send more streams on the same connection
-                if let Err(_closed) = send.finish() {
-                    log::warn!("Failed to finish stream to {service_name}");
-                }
-            }
-            Ok(None) => {
-                // Stream closed gracefully by peer
-                log::debug!("Stream closed by peer for {}", service_name);
-                // Continue: connection may have more streams
-            }
-            Err(e) => {
-                // Read error: log and continue accepting streams
-                log::debug!("Read error for {}: {:?}", service_name, e);
-                // Don't break: connection might still accept new streams
-            }
-        }
-    }
-}
-
-async fn initiate_connection(
-    connector: &QuicConnector,
-    src: &str,
-    dst: &str,
-) -> Result<(), Report<Error>> {
-    // Establish connection to destination service
-    let conn = connector
-        .connect(dst)
-        .await
-        .change_context(Error(format!("Failed to connect to {dst}")))?;
-
-    // Open a new bidirectional stream
-    let (mut send, mut recv) = conn.open_bi().await.change_context(Error(format!(
-        "Failed to open bidirectional stream to {dst}"
-    )))?;
-
-    // Send hello message
-    let hello = format!("Hello from {src}");
-    send.write_all(hello.as_bytes())
-        .await
-        .change_context(Error(format!("Failed to write hello message to {dst}")))?;
-    log::info!("> [{}] {}", src, hello);
-
-    // Signal we're done sending on this stream
-    send.finish()
-        .change_context(Error(format!("Failed to finish send stream to {dst}")))?;
-
-    let mut buf = vec![0u8; 1024];
-    match recv.read(&mut buf).await {
-        Ok(Some(n)) => {
-            // Successfully received response
-            let msg = String::from_utf8_lossy(&buf[..n]);
-            log::info!("< [{}] {}", dst, msg);
-        }
-        Ok(None) => {
-            // Peer closed stream before sending response
-            log::debug!("< [{}] Peer closed stream without response", dst);
-        }
-        Err(e) => {
-            // Read error: log but don't fail the whole operation
-            // The hello was already sent successfully
-            log::debug!("< [{}] Read error: {:?}", dst, e);
-        }
-    }
-    // Connection will be closed on Drop
     Ok(())
 }
 

--- a/src/northbound/inbound.rs
+++ b/src/northbound/inbound.rs
@@ -4,7 +4,7 @@
 use error_stack::ResultExt;
 
 use crate::{
-    Socks5Addr,
+    Socks5Targets,
     core::transport::QuicConnector,
     northbound::inbound::socks5::{Socks5Handle, Socks5Inbound},
     utils::report::ErrorReport,
@@ -21,10 +21,10 @@ pub struct Error(String);
 /// This groups inbound listener inputs consumed by [`InboundBundle::try_new`].
 #[fundle::deps]
 pub struct InboundDeps {
-    /// Optional local address for exposing a SOCKS5 listener.
+    /// Local SOCKS5 listener addresses keyed by client service name.
     ///
-    /// When `None`, SOCKS5 inbound is disabled.
-    socks5_addr: Option<Socks5Addr>,
+    /// When empty, SOCKS5 inbound is disabled.
+    socks5_targets: Socks5Targets,
     /// QUIC connector used by inbound handlers to establish upstream sessions.
     quic_connector: QuicConnector,
 }
@@ -42,7 +42,7 @@ pub struct InboundBundle {
 impl InboundBundle {
     /// Build the bundle from the given dependencies.
     ///
-    /// [`Socks5Inbound`] is only created if a `socks5_addr` is provided in the config.
+    /// [`Socks5Inbound`] is only created if `socks5_targets` is not empty.
     /// It's immediately spawned within the bundle to ensure it lives for the duration of the app.
     pub async fn try_new(deps: impl Into<InboundDeps>) -> Result<Self, ErrorReport<Error>> {
         let deps = deps.into();
@@ -53,15 +53,17 @@ impl InboundBundle {
 }
 
 async fn init_socks5(deps: &InboundDeps) -> Result<Option<Socks5Handle>, ErrorReport<Error>> {
-    let socks5 = if let Some(addr) = deps.socks5_addr.clone() {
-        let socks5 = Socks5Inbound::new(addr.0, deps.quic_connector.clone())
+    let socks5 = if deps.socks5_targets.0.is_empty() {
+        None
+    } else {
+        let socks5 = Socks5Inbound::new(deps.socks5_targets.0.clone(), deps.quic_connector.clone())
             .await
             .change_context(Error("Failed to create SOCKS5 inbound".into()))?
             .spawn();
-        log::info!("SOCKS5 server listening on {}", addr.0);
+        for (service_name, addr) in &deps.socks5_targets.0 {
+            log::info!("SOCKS5 service '{service_name}' listening on {addr}");
+        }
         Some(socks5)
-    } else {
-        None
     };
     Ok(socks5)
 }

--- a/src/northbound/inbound.rs
+++ b/src/northbound/inbound.rs
@@ -1,10 +1,11 @@
 // Copyright (C) 2026 ReteLabs LLC.
 // Licensed under Apache-2.0 or MIT at your option.
 
+use std::{collections::HashMap, net::SocketAddr};
+
 use error_stack::ResultExt;
 
 use crate::{
-    Socks5Targets,
     core::transport::QuicConnector,
     northbound::inbound::socks5::{Socks5Handle, Socks5Inbound},
     utils::report::ErrorReport,
@@ -16,6 +17,9 @@ pub mod socks5;
 #[error("{0}")]
 pub struct Error(String);
 
+#[derive(Debug, Clone)]
+pub struct Socks5Bindings(pub HashMap<String, SocketAddr>);
+
 /// Dependencies required to construct an [`InboundBundle`].
 ///
 /// This groups inbound listener inputs consumed by [`InboundBundle::try_new`].
@@ -24,7 +28,7 @@ pub struct InboundDeps {
     /// Local SOCKS5 listener addresses keyed by client service name.
     ///
     /// When empty, SOCKS5 inbound is disabled.
-    socks5_targets: Socks5Targets,
+    socks5_bindings: Socks5Bindings,
     /// QUIC connector used by inbound handlers to establish upstream sessions.
     quic_connector: QuicConnector,
 }
@@ -42,7 +46,7 @@ pub struct InboundBundle {
 impl InboundBundle {
     /// Build the bundle from the given dependencies.
     ///
-    /// [`Socks5Inbound`] is only created if `socks5_targets` is not empty.
+    /// [`Socks5Inbound`] is only created if `socks5_bindings` is not empty.
     /// It's immediately spawned within the bundle to ensure it lives for the duration of the app.
     pub async fn try_new(deps: impl Into<InboundDeps>) -> Result<Self, ErrorReport<Error>> {
         let deps = deps.into();
@@ -53,14 +57,15 @@ impl InboundBundle {
 }
 
 async fn init_socks5(deps: &InboundDeps) -> Result<Option<Socks5Handle>, ErrorReport<Error>> {
-    let socks5 = if deps.socks5_targets.0.is_empty() {
+    let socks5 = if deps.socks5_bindings.0.is_empty() {
         None
     } else {
-        let socks5 = Socks5Inbound::new(deps.socks5_targets.0.clone(), deps.quic_connector.clone())
-            .await
-            .change_context(Error("Failed to create SOCKS5 inbound".into()))?
-            .spawn();
-        for (service_name, addr) in &deps.socks5_targets.0 {
+        let socks5 =
+            Socks5Inbound::new(deps.socks5_bindings.0.clone(), deps.quic_connector.clone())
+                .await
+                .change_context(Error("Failed to create SOCKS5 inbound".into()))?
+                .spawn();
+        for (service_name, addr) in &deps.socks5_bindings.0 {
             log::info!("SOCKS5 service '{service_name}' listening on {addr}");
         }
         Some(socks5)

--- a/src/northbound/inbound/socks5.rs
+++ b/src/northbound/inbound/socks5.rs
@@ -107,10 +107,10 @@ impl Socks5Inbound {
     /// Bind client-specific listeners and return a component ready to be started via
     /// [`spawn`](Self::spawn).
     pub async fn new(
-        targets: HashMap<String, SocketAddr>,
+        bindings: HashMap<String, SocketAddr>,
         connector: QuicConnector,
     ) -> Result<Self, Report<Error>> {
-        let listeners = bind_listeners(targets).await?;
+        let listeners = bind_listeners(bindings).await?;
         Ok(Self {
             listeners,
             backend: Arc::new(connector),
@@ -136,10 +136,10 @@ impl Socks5Inbound {
 }
 
 async fn bind_listeners(
-    targets: HashMap<String, SocketAddr>,
+    bindings: HashMap<String, SocketAddr>,
 ) -> Result<HashMap<String, TcpListener>, Report<Error>> {
-    let mut listeners = HashMap::with_capacity(targets.len());
-    for (service_name, listen_addr) in targets {
+    let mut listeners = HashMap::with_capacity(bindings.len());
+    for (service_name, listen_addr) in bindings {
         let listener = TcpListener::bind(listen_addr)
             .await
             .change_context_lazy(|| {

--- a/src/northbound/inbound/socks5.rs
+++ b/src/northbound/inbound/socks5.rs
@@ -6,6 +6,7 @@ use error_stack::{FutureExt, IntoReport, Report, ResultExt, bail};
 use fast_socks5::server::Socks5ServerProtocol;
 use fast_socks5::util::target_addr::TargetAddr;
 use fast_socks5::{ReplyError, Socks5Command};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -79,41 +80,39 @@ impl QuicBackend for QuicConnector {
 
 /// Lifecycle handle for a running [`Socks5Inbound`].
 ///
-/// Dropping this handle aborts the accept loop and all in-flight connections.
+/// Dropping this handle aborts the accept loops and all in-flight connections.
 /// Call [`shutdown`](Self::shutdown) to also await full termination of the accept
-/// loop task.
+/// loop tasks.
 pub struct Socks5Handle(LifecycleHandle);
 
 impl_lifecycle_handle!(Socks5Handle);
 
 /// SOCKS5 inbound component.
 ///
-/// Accepts TCP connections, performs the SOCKS5 handshake, then forwards each
-/// `TCP_CONNECT` request to the given [`QuicConnector`]. The domain name from
-/// the SOCKS5 target address is used directly as the QUIC service name.
+/// Accepts TCP connections on client-specific listeners, performs the SOCKS5
+/// handshake, then forwards each `TCP_CONNECT` request to the given
+/// [`QuicConnector`]. The domain name from the SOCKS5 target address is used
+/// directly as the QUIC service name.
 ///
 /// # Lifecycle
 ///
 /// Call [`spawn`](Self::spawn) to start and obtain a [`Socks5Handle`].
-/// Dropping the handle stops the accept loop.
+/// Dropping the handle stops all accept loops.
 pub struct Socks5Inbound {
-    listener: TcpListener,
+    listeners: HashMap<String, TcpListener>,
     backend: Arc<dyn QuicBackend>,
 }
 
 impl Socks5Inbound {
-    /// Bind to `listen_addr` and return a component ready to be started via [`spawn`](Self::spawn).
+    /// Bind client-specific listeners and return a component ready to be started via
+    /// [`spawn`](Self::spawn).
     pub async fn new(
-        listen_addr: SocketAddr,
+        targets: HashMap<String, SocketAddr>,
         connector: QuicConnector,
     ) -> Result<Self, Report<Error>> {
-        let listener = TcpListener::bind(listen_addr)
-            .await
-            .change_context_lazy(|| {
-                Error(format!("Failed to bind SOCKS5 server to {listen_addr}"))
-            })?;
+        let listeners = bind_listeners(targets).await?;
         Ok(Self {
-            listener,
+            listeners,
             backend: Arc::new(connector),
         })
     }
@@ -125,31 +124,64 @@ impl Socks5Inbound {
 
     async fn run(self) {
         let mut tasks = JoinSet::new();
-        loop {
-            tokio::select! {
-                result = self.listener.accept() => match result {
-                    Ok((stream, peer_addr)) => {
-                        log::debug!(target: LOG_TARGET, "Accepted connection from {peer_addr}");
-                        let backend = self.backend.clone();
-                        tasks.spawn(async move {
-                            if let Err(e) = handle_socks5(stream, backend).await {
-                                log::warn!(target: LOG_TARGET,
-                                    "Connection from {peer_addr} error: {e:?}");
-                            }
-                        });
-                    }
-                    Err(e) => {
-                        log::error!(target: LOG_TARGET, "Accept error: {e:?}");
-                        break;
-                    }
-                },
-
-                // Reap finished tasks to keep the set bounded.
-                Some(_) = tasks.join_next() => {}
-            }
+        for (service_name, listener) in self.listeners {
+            let backend = self.backend.clone();
+            tasks.spawn(run_listener(service_name, listener, backend));
         }
-        // Dropping JoinSet here aborts all in-flight connection tasks.
+
+        // Any listener stopping terminates the whole inbound. Dropping the set
+        // aborts the remaining listeners and their in-flight connections.
+        let _ = tasks.join_next().await;
     }
+}
+
+async fn bind_listeners(
+    targets: HashMap<String, SocketAddr>,
+) -> Result<HashMap<String, TcpListener>, Report<Error>> {
+    let mut listeners = HashMap::with_capacity(targets.len());
+    for (service_name, listen_addr) in targets {
+        let listener = TcpListener::bind(listen_addr)
+            .await
+            .change_context_lazy(|| {
+                Error(format!(
+                    "Failed to bind SOCKS5 service '{service_name}' to {listen_addr}"
+                ))
+            })?;
+        listeners.insert(service_name, listener);
+    }
+    Ok(listeners)
+}
+
+async fn run_listener(service_name: String, listener: TcpListener, backend: Arc<dyn QuicBackend>) {
+    let mut tasks = JoinSet::new();
+    loop {
+        tokio::select! {
+            result = listener.accept() => match result {
+                Ok((stream, peer_addr)) => {
+                    log::debug!(target: LOG_TARGET,
+                        "Accepted connection from {peer_addr} via SOCKS5 service '{service_name}'");
+                    let backend = backend.clone();
+                    let service_name = service_name.clone();
+                    tasks.spawn(async move {
+                        if let Err(e) = handle_socks5(stream, backend).await {
+                            log::warn!(target: LOG_TARGET,
+                                "Connection from {peer_addr} via SOCKS5 service '{service_name}'
+                                error: {e:?}");
+                        }
+                    });
+                }
+                Err(e) => {
+                    log::error!(target: LOG_TARGET,
+                        "SOCKS5 service '{service_name}' accept error: {e:?}");
+                    break;
+                }
+            },
+
+            // Reap finished tasks to keep the set bounded.
+            Some(_) = tasks.join_next() => {}
+        }
+    }
+    // Dropping JoinSet here aborts all in-flight connection tasks.
 }
 
 /// Handles a single SOCKS5 connection: performs the handshake, opens connection to the target,
@@ -251,8 +283,18 @@ mod tests {
     }
 
     fn inbound(listener: TcpListener, backend: impl QuicBackend + 'static) -> Socks5Inbound {
+        inbound_with_listeners(
+            HashMap::from([("test-client".to_string(), listener)]),
+            backend,
+        )
+    }
+
+    fn inbound_with_listeners(
+        listeners: HashMap<String, TcpListener>,
+        backend: impl QuicBackend + 'static,
+    ) -> Socks5Inbound {
         Socks5Inbound {
-            listener,
+            listeners,
             backend: Arc::new(backend),
         }
     }
@@ -355,11 +397,38 @@ mod tests {
     // --- Tests ---
 
     #[tokio::test]
-    async fn test_actor_binds_and_accepts() {
-        let (listener, addr) = bound_listener().await;
-        let _handle = inbound(listener, MockFailingQuicBackend).spawn();
+    async fn test_actor_accepts_on_all_listeners() {
+        let (alice_listener, alice_addr) = bound_listener().await;
+        let (bob_listener, bob_addr) = bound_listener().await;
+        let _handle = inbound_with_listeners(
+            HashMap::from([
+                ("alice".to_string(), alice_listener),
+                ("bob".to_string(), bob_listener),
+            ]),
+            MockFailingQuicBackend,
+        )
+        .spawn();
 
-        TcpStream::connect(addr).await.unwrap();
+        TcpStream::connect(alice_addr).await.unwrap();
+        TcpStream::connect(bob_addr).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bind_failure_releases_previously_bound_listeners() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let result = bind_listeners(HashMap::from([
+            ("alice".to_string(), addr),
+            ("bob".to_string(), addr),
+        ]))
+        .await;
+        assert!(result.is_err(), "duplicate listen address must fail");
+
+        TcpListener::bind(addr)
+            .await
+            .expect("listener bound before the error must be released");
     }
 
     #[tokio::test]
@@ -427,22 +496,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_dropped_stops_actor() {
-        let (listener, addr) = bound_listener().await;
-        let handle = inbound(listener, MockFailingQuicBackend).spawn();
+    async fn test_shutdown_stops_all_listeners() {
+        let (alice_listener, alice_addr) = bound_listener().await;
+        let (bob_listener, bob_addr) = bound_listener().await;
+        let handle = inbound_with_listeners(
+            HashMap::from([
+                ("alice".to_string(), alice_listener),
+                ("bob".to_string(), bob_listener),
+            ]),
+            MockFailingQuicBackend,
+        )
+        .spawn();
 
-        // Actor is running — connection should succeed
-        TcpStream::connect(addr).await.unwrap();
+        // Actor is running: connections to both listeners should succeed.
+        TcpStream::connect(alice_addr).await.unwrap();
+        TcpStream::connect(bob_addr).await.unwrap();
 
-        // Drop handle — actor shuts down
+        // Shutting down the handle stops both listeners.
         let _ = handle.shutdown().await;
 
-        // New connections should be refused now
-        let result = tokio::time::timeout(Duration::from_secs(1), TcpStream::connect(addr)).await;
-        assert!(
-            result.is_err() || result.unwrap().is_err(),
-            "connections should fail after shutdown"
-        );
+        for addr in [alice_addr, bob_addr] {
+            let result =
+                tokio::time::timeout(Duration::from_secs(1), TcpStream::connect(addr)).await;
+            assert!(
+                result.is_err() || result.unwrap().is_err(),
+                "connections to {addr} should fail after shutdown"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/northbound/inbound/socks5.rs
+++ b/src/northbound/inbound/socks5.rs
@@ -8,7 +8,7 @@ use fast_socks5::util::target_addr::TargetAddr;
 use fast_socks5::{ReplyError, Socks5Command};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::{JoinHandle, JoinSet};
 
@@ -215,17 +215,20 @@ async fn handle_socks5(
 
     log::debug!(target: LOG_TARGET, "Relaying traffic for '{target}'");
 
-    tokio::select! {
-        res = tokio::io::copy(&mut client_read, &mut quic_send) => {
-            if let Err(e) = res {
-                log::debug!(target: LOG_TARGET, "Client->QUIC relay error for '{target}': {e:?}");
-            }
-        }
-        res = tokio::io::copy(&mut quic_recv, &mut client_write) => {
-            if let Err(e) = res {
-                log::debug!(target: LOG_TARGET, "QUIC->Client relay error for '{target}': {e:?}");
-            }
-        }
+    let client_to_quic = async {
+        let _ = tokio::io::copy(&mut client_read, &mut quic_send).await?;
+        quic_send.shutdown().await
+    };
+    let quic_to_client = async {
+        let _ = tokio::io::copy(&mut quic_recv, &mut client_write).await?;
+        client_write.shutdown().await
+    };
+    let (client_to_quic, quic_to_client) = tokio::join!(client_to_quic, quic_to_client);
+    if let Err(e) = client_to_quic {
+        log::debug!(target: LOG_TARGET, "Client->QUIC relay error for '{target}': {e:?}");
+    }
+    if let Err(e) = quic_to_client {
+        log::debug!(target: LOG_TARGET, "QUIC->Client relay error for '{target}': {e:?}");
     }
 
     Ok(())
@@ -481,5 +484,16 @@ mod tests {
             .expect("timeout")
             .unwrap();
         assert_eq!(&buf, b"hello from client");
+
+        // A client such as `printf ... | nc` closes its write half immediately after sending.
+        // The reverse relay must remain alive long enough to deliver the backend response.
+        client.shutdown().await.unwrap();
+        backend_stream.write_all(b"reply after eof").await.unwrap();
+        let mut buf = vec![0u8; 15];
+        tokio::time::timeout(Duration::from_secs(2), client.read_exact(&mut buf))
+            .await
+            .expect("timeout")
+            .unwrap();
+        assert_eq!(&buf, b"reply after eof");
     }
 }

--- a/src/northbound/outbound.rs
+++ b/src/northbound/outbound.rs
@@ -1,12 +1,13 @@
 // Copyright (C) 2026 ReteLabs LLC.
 // Licensed under Apache-2.0 or MIT at your option.
 
+use std::{collections::HashMap, net::SocketAddr};
+
 use async_trait::async_trait;
 use error_stack::{Report, ResultExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::{
-    TcpDirectTargets,
     core::transport::{
         QuicPublisher,
         endpoint::connection::{Accept, QuicConnection},
@@ -20,6 +21,9 @@ pub mod tcp;
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct Error(String);
+
+#[derive(Debug, Clone)]
+pub struct TcpDirectBindings(pub HashMap<String, SocketAddr>);
 
 trait QuicStream: AsyncRead + AsyncWrite + Unpin + Send {}
 
@@ -45,7 +49,7 @@ impl QuicInboundConnection for QuicConnection {
 #[fundle::deps]
 pub struct OutboundDeps {
     /// Service names served by this node and their TCP targets.
-    tcp_direct_targets: TcpDirectTargets,
+    tcp_direct_bindings: TcpDirectBindings,
     /// QUIC publisher used by outbound handlers to subscribe to incoming sessions.
     quic_publisher: QuicPublisher,
 }
@@ -69,16 +73,17 @@ impl OutboundBundle {
 async fn init_tcp_direct(
     deps: OutboundDeps,
 ) -> Result<Option<TcpDirectHandle>, ErrorReport<Error>> {
-    if deps.tcp_direct_targets.0.is_empty() {
+    if deps.tcp_direct_bindings.0.is_empty() {
         return Ok(None);
     }
 
-    let tcp_direct = TcpDirectOutbound::new(deps.tcp_direct_targets.0.clone(), deps.quic_publisher)
-        .await
-        .change_context(Error("Failed to create TCP direct outbound".into()))?
-        .spawn();
+    let tcp_direct =
+        TcpDirectOutbound::new(deps.tcp_direct_bindings.0.clone(), deps.quic_publisher)
+            .await
+            .change_context(Error("Failed to create TCP direct outbound".into()))?
+            .spawn();
 
-    for (service_name, addr) in &deps.tcp_direct_targets.0 {
+    for (service_name, addr) in &deps.tcp_direct_bindings.0 {
         log::info!("TCP direct outbound serving '{service_name}' on '{addr}'");
     }
     Ok(Some(tcp_direct))

--- a/src/northbound/outbound/tcp.rs
+++ b/src/northbound/outbound/tcp.rs
@@ -36,16 +36,16 @@ impl_lifecycle_handle!(TcpDirectHandle);
 /// forwards every accepted bidirectional stream to the matching TCP address.
 pub struct TcpDirectOutbound {
     acceptor: QuicAcceptor,
-    targets: Arc<HashMap<String, SocketAddr>>,
+    bindings: Arc<HashMap<String, SocketAddr>>,
 }
 
 impl TcpDirectOutbound {
     /// Publish the configured service names and return a component ready to start.
     pub async fn new(
-        targets: HashMap<String, SocketAddr>,
+        bindings: HashMap<String, SocketAddr>,
         publisher: QuicPublisher,
     ) -> Result<Self, Report<Error>> {
-        let served = targets.keys().cloned().collect::<Vec<_>>();
+        let served = bindings.keys().cloned().collect::<Vec<_>>();
         let acceptor = publisher
             .publish(served)
             .await
@@ -53,7 +53,7 @@ impl TcpDirectOutbound {
 
         Ok(Self {
             acceptor,
-            targets: Arc::new(targets),
+            bindings: Arc::new(bindings),
         })
     }
 
@@ -69,9 +69,9 @@ impl TcpDirectOutbound {
             tokio::select! {
                 accepted = self.acceptor.accept() => match accepted {
                     Some((service_name, conn)) => {
-                        let targets = self.targets.clone();
+                        let bindings = self.bindings.clone();
                         tasks.spawn(async move {
-                            handle_connection(service_name, conn, targets).await;
+                            handle_connection(service_name, conn, bindings).await;
                         });
                     }
                     None => {
@@ -94,9 +94,9 @@ impl TcpDirectOutbound {
 async fn handle_connection(
     service_name: String,
     conn: impl QuicInboundConnection + 'static,
-    targets: Arc<HashMap<String, SocketAddr>>,
+    bindings: Arc<HashMap<String, SocketAddr>>,
 ) {
-    let Some(target_addr) = targets.get(&service_name).copied() else {
+    let Some(target_addr) = bindings.get(&service_name).copied() else {
         log::debug!(target: LOG_TARGET, "No TCP target configured for '{service_name}'");
         return;
     };


### PR DESCRIPTION
Changes:
1. Vertex config for `flor demo` is updated. Now it has the following view:
   ```
   "Alpha", // node name
            (
                "127.0.0.1:31337", // QUIC address
                vec![
                    ("alice", "127.0.0.1:1080"),
                    ("bob", "127.0.0.1:1081"),
                ], // SOCKS5 workloads
                vec![
                    ("tcp-echo.beta.demo-cluster.rete",  "127.0.0.1:32450"),
                ], // TCP services
            ),
   
   ```
2. Legacy direct QUIC -> QUIC demo is removed.
3. Fixed half-close flow at Socks5Inbound.
4. Add multiple SOCKS5 servers support into Socks5Inbound.

How to test:
1. Run `cargo run --bin flor -- demo --name Alpha` at the first terminal.
2. Run `cargo run --bin flor -- demo --name Beta` at the second terminal.
3. Run TCP echo server: `socat TCP-LISTEN:32450,reuseaddr,fork EXEC:/bin/cat` at the third terminal.
4. Run `printf 'hello through flor\n' |  nc -X 5 -x 127.0.0.1:1081 tcp-echo.beta.demo-cluster.rete 1234` for sending a message through the flor.

Refs: #33 