### PR TITLE
feat: migrate our logger to tracing (#67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,29 +392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,12 +460,12 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 name = "flor"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
  "ctor",
- "env_logger",
  "error-stack",
  "fast-socks5",
  "fundle",
@@ -510,6 +487,9 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "x509-parser",
 ]
 
@@ -684,30 +664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +763,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +840,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -985,21 +959,6 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]
@@ -1175,18 +1134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1494,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,7 +1719,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1764,6 +1741,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1789,6 +1796,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }
-env_logger = "0.11"
 error-stack = "0.7"
 fast-socks5 = "1.0"
 fundle = "0.3"
@@ -25,12 +24,16 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 
 # Using "ring" backend across all crypto libs, as quinn uses it by default
+anstyle = "1.0"
+pem = "3"
 quinn = { version = "0.11" }
-rcgen = { version = "0.14", default-features = false, features = ["ring", "pem", "x509-parser"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "ring", "x509-parser"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 spiffe = { version = "0.15", default-features = false, features = ["x509"] }
-pem = "3"
 time = { version = "0.3", default-features = false, features = ["std"] }
+tracing = "0.1"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]

--- a/src/bin/retectl.rs
+++ b/src/bin/retectl.rs
@@ -138,7 +138,7 @@ fn main() {
     let cli = Cli::parse();
 
     if DEBUG {
-        let _ = flor::logging::logger::init(log::LevelFilter::Info);
+        let _ = flor::logging::logger::init(flor::logging::logger::LevelFilter::INFO);
     }
 
     if let Err(e) = run(cli.cmd) {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,9 +13,9 @@ pub struct Error(String);
 fn init_global_test_logging() {
     logger::init_with_config(
         &logger::Config::new()
-            .global_log_filter(log::LevelFilter::Off)
+            .global_log_filter(logger::LevelFilter::OFF)
             // Explicitly disable spammy logs of serial_test crate
-            .module_log_filter("serial_test".into(), log::LevelFilter::Off),
+            .module_log_filter("serial_test".into(), logger::LevelFilter::OFF),
     )
     .expect("Failed to initialize logger");
 }

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -1,14 +1,38 @@
 // Copyright (C) 2026 ReteLabs LLC.
 // Licensed under Apache-2.0 or MIT at your option.
 
-use std::{borrow::Cow, io::Write};
+//! The process-wide logger: a `tracing` subscriber rendering one line per event.
+//!
+//! Events reach it from both facades — `tracing::` macros and, through
+//! `LogTracer`, the `log::` macros used by flor and its dependencies — so a
+//! single filter and format govern everything. Enclosing spans are rendered
+//! before the message, which is how an event emitted deep inside a connection
+//! handler carries that connection's identity without being passed it.
+//!
+//! Call [`init`] or [`init_with_config`] once per process, before anything logs.
+//! `RUST_LOG` overrides the [`Config`] filters and accepts the usual
+//! `target=level` syntax.
 
+use std::borrow::Cow;
+use std::fmt;
+use std::io::IsTerminal;
+
+use anstyle::{AnsiColor, Effects, Style};
 use chrono::Local;
-use env_logger::fmt::style::{self, Style};
 use error_stack::{Report, ResultExt};
-use log::LevelFilter;
+use tracing::{Event, Subscriber};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::logging::Error;
+
+/// Severity threshold for the logger, re-exported so call sites depend on this
+/// module's vocabulary rather than on whichever facade backs it.
+pub use tracing::level_filters::LevelFilter;
 
 const SHORTENED_TARGET_MAX_LEN: usize = 20;
 
@@ -81,7 +105,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            global_log_filter: LevelFilter::Info,
+            global_log_filter: LevelFilter::INFO,
             modules_log_filter: vec![],
             include_time: true,
             include_date: false,
@@ -99,11 +123,10 @@ impl Default for Config {
 ///
 /// ### Examples
 /// ```
-/// use log::LevelFilter;
-/// use flor::logging::logger;
+/// use flor::logging::logger::{self, LevelFilter};
 ///
-/// logger::init(LevelFilter::Info).unwrap();
-/// log::info!("Logger is initialized!");
+/// logger::init(LevelFilter::INFO).unwrap();
+/// tracing::info!("Logger is initialized!");
 /// ```
 pub fn init(log_level: LevelFilter) -> Result<(), Report<Error>> {
     init_with_config(&Config::new().global_log_filter(log_level))
@@ -122,87 +145,204 @@ pub fn init(log_level: LevelFilter) -> Result<(), Report<Error>> {
 ///
 /// ### Examples
 /// ```
-/// use log::LevelFilter;
-/// use flor::logging::logger;
+/// use flor::logging::logger::{self, LevelFilter};
 ///
 /// logger::init_with_config(
 ///     &logger::Config::new()
-///         .global_log_filter(LevelFilter::Debug)
-///         .module_log_filter("my_crate".into(), LevelFilter::Info)
+///         .global_log_filter(LevelFilter::DEBUG)
+///         .module_log_filter("my_crate".into(), LevelFilter::INFO)
 ///         .include_shortened_target(false)
 ///         .include_time(false)
 /// );
-/// log::info!("Logger is initialized with custom config!");
+/// tracing::info!("Logger is initialized with custom config!");
 /// ```
 pub fn init_with_config(config: &Config) -> Result<(), Report<Error>> {
-    let mut env_builder = env_logger::Builder::new();
+    let format = FlorFormat {
+        include_time: config.include_time,
+        include_date: config.include_date,
+        include_shortened_target: config.include_shortened_target,
+    };
 
-    env_builder.filter_level(config.global_log_filter);
+    // Never colorize a non-terminal sink.
+    let ansi = std::io::stderr().is_terminal();
 
-    config
-        .modules_log_filter
-        .iter()
-        .for_each(|(module, level)| {
-            env_builder.filter_module(module, *level);
-        });
-
-    let include_time = config.include_time;
-    let include_date = config.include_date;
-    let include_shortened_target = config.include_shortened_target;
-    env_builder.format(move |buf, record| {
-        let comp_style = style::AnsiColor::BrightBlack.on_default();
-        if include_time || include_date {
-            write_timestamp(buf, &comp_style, include_time, include_date)?;
-        }
-
-        let level_style = buf.default_level_style(record.level());
-        write!(buf, "{level_style}{:>5}{level_style:#} ", record.level())?;
-
-        if include_shortened_target {
-            write_target(buf, &comp_style, record.target())?;
-        }
-
-        writeln!(buf, "{}", record.args())
+    // `tracing-subscriber` rewrites escape sequences found *inside* a message, as
+    // a terminal-injection defense — our messages carry peer-controlled text
+    // (hostnames, SPIFFE IDs, remote error strings), so a release build always
+    // keeps it. The cost is that a styled `Report` arrives mangled rather than
+    // colored, since its escapes travel inside the message.
+    //
+    // Debug builds trade that away: a developer reading an error stack in a
+    // terminal benefits from the color, and the peers involved are their own. The
+    // relaxation is scoped as narrowly as it can be — debug build *and* a terminal
+    // sink — so a redirected dev log is still sanitized.
+    // Release's log is always sanitized.
+    let styled_reports = ansi && cfg!(debug_assertions);
+    Report::set_color_mode(if styled_reports {
+        error_stack::fmt::ColorMode::Color
+    } else {
+        error_stack::fmt::ColorMode::None
     });
 
-    env_builder.parse_default_env();
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(ansi)
+        .with_ansi_sanitization(!styled_reports)
+        .event_format(format);
 
-    env_builder
+    tracing_subscriber::registry()
+        .with(build_filter(config)?)
+        .with(fmt_layer)
         .try_init()
         .change_context(Error("Failed to set logger".into()))
 }
 
-fn write_timestamp(
-    w: &mut dyn Write,
-    style: &Style,
+/// Maps the `Config` filters onto an `EnvFilter`, with `RUST_LOG` taking precedence.
+///
+/// The two sources are parsed with deliberately different strictness. `RUST_LOG`
+/// is operator input typed at runtime, so an unusable directive is dropped with a
+/// warning on stderr (`ignoring \`x=debgu\`: …`) and the rest still applies.
+/// This behaviour is justified because we cannot ensure that `RUST_LOG` is fully
+/// correct: a typo in a component name cannot be detected.
+///
+/// On the other hand, `Config` directives are programmer input, so a malformed one
+/// is a bug and fails initialization instead of being skipped.
+fn build_filter(config: &Config) -> Result<tracing_subscriber::EnvFilter, Report<Error>> {
+    if let Ok(env) = std::env::var("RUST_LOG")
+        && !env.is_empty()
+    {
+        return Ok(tracing_subscriber::EnvFilter::new(env));
+    }
+
+    let mut directives = vec![config.global_log_filter.to_string()];
+    for (module, level) in &config.modules_log_filter {
+        directives.push(format!("{module}={level}"));
+    }
+    let directives = directives.join(",");
+    tracing_subscriber::EnvFilter::try_new(&directives)
+        .change_context_lazy(|| Error(format!("Invalid log filter directives: '{directives}'")))
+}
+
+/// Renders one event as `<time> <LEVEL> <component>: <spans> <message+fields>`.
+struct FlorFormat {
     include_time: bool,
     include_date: bool,
-) -> std::io::Result<()> {
-    if include_time || include_date {
-        let time = Local::now();
-        if include_date {
-            write!(w, "{style}{}{style:#} ", time.format("%Y-%m-%d"))?;
+    include_shortened_target: bool,
+}
+
+impl<S, N> FormatEvent<S, N> for FlorFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let greyed_style = AnsiColor::BrightBlack.on_default();
+        let ansi = writer.has_ansi_escapes();
+
+        if self.include_time || self.include_date {
+            write_timestamp(
+                &mut writer,
+                &greyed_style,
+                ansi,
+                self.include_time,
+                self.include_date,
+            )?;
         }
-        if include_time {
-            write!(w, "{style}{}{style:#} ", time.format("%H:%M:%S%.3f"))?;
+
+        // Records arriving through the `log` bridge carry their real target and
+        // level in `log.*` fields; normalizing recovers them.
+        let normalized = event.normalized_metadata();
+        let meta = normalized.as_ref().unwrap_or_else(|| event.metadata());
+
+        let level_style = level_style(meta.level());
+        write_styled(
+            &mut writer,
+            &level_style,
+            ansi,
+            &format!("{:>5}", meta.level().as_str()),
+        )?;
+        write!(writer, " ")?;
+
+        if self.include_shortened_target {
+            write_target(&mut writer, &greyed_style, ansi, meta.target())?;
         }
+
+        // Every enclosing span, root-first, with its fields. Deliberately not
+        // wrapped in a style of our own: the field renderer already styles names
+        // and separators, and its escapes end with a full reset, which would cut
+        // any enclosing style off partway through anyway.
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                let ext = span.extensions();
+                match ext.get::<FormattedFields<N>>() {
+                    Some(fields) if !fields.is_empty() => {
+                        write!(writer, "{}{{{}}} ", span.name(), fields.fields.as_str())?
+                    }
+                    _ => write!(writer, "{} ", span.name())?,
+                }
+            }
+        }
+
+        ctx.format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
+
+fn write_styled(w: &mut Writer<'_>, style: &Style, ansi: bool, text: &str) -> fmt::Result {
+    if ansi {
+        write!(w, "{style}{text}{style:#}")
+    } else {
+        write!(w, "{text}")
+    }
+}
+
+fn level_style(level: &tracing::Level) -> Style {
+    match *level {
+        tracing::Level::ERROR => AnsiColor::Red.on_default().effects(Effects::BOLD),
+        tracing::Level::WARN => AnsiColor::Yellow.on_default(),
+        tracing::Level::INFO => AnsiColor::Green.on_default(),
+        tracing::Level::DEBUG => AnsiColor::Blue.on_default(),
+        tracing::Level::TRACE => AnsiColor::Cyan.on_default(),
+    }
+}
+
+fn write_timestamp(
+    w: &mut Writer<'_>,
+    style: &Style,
+    ansi: bool,
+    include_time: bool,
+    include_date: bool,
+) -> fmt::Result {
+    let time = Local::now();
+    if include_date {
+        write_styled(w, style, ansi, &format!("{} ", time.format("%Y-%m-%d")))?;
+    }
+    if include_time {
+        write_styled(w, style, ansi, &format!("{} ", time.format("%H:%M:%S%.3f")))?;
     }
     Ok(())
 }
 
-fn write_target(w: &mut dyn Write, style: &Style, target: &str) -> std::io::Result<()> {
-    let shortened_target = target.split_once("::").map_or(target, |(first, _)| first);
+fn write_target(w: &mut Writer<'_>, style: &Style, ansi: bool, target: &str) -> fmt::Result {
+    write_styled(w, style, ansi, &format!("{}: ", shorten_target(target)))
+}
 
-    let mut chars = shortened_target.char_indices();
-    let cut = chars.nth(SHORTENED_TARGET_MAX_LEN).map(|(i, _)| i);
+/// Reduces a log target to its first path segment, capped in length.
+///
+/// `my_crate::module::submodule` becomes `my_crate`; a custom target is taken
+/// as-is up to the cap.
+fn shorten_target(target: &str) -> &str {
+    let shortened = target.split_once("::").map_or(target, |(first, _)| first);
 
-    match cut {
-        Some(idx) => {
-            write!(w, "{style}{}:{style:#} ", &shortened_target[..idx])
-        }
-        None => {
-            write!(w, "{style}{shortened_target}:{style:#} ")
-        }
+    let mut chars = shortened.char_indices();
+    match chars.nth(SHORTENED_TARGET_MAX_LEN).map(|(i, _)| i) {
+        Some(idx) => &shortened[..idx],
+        None => shortened,
     }
 }
 
@@ -210,41 +350,28 @@ fn write_target(w: &mut dyn Write, style: &Style, target: &str) -> std::io::Resu
 mod tests {
     use super::*;
 
-    fn default_style() -> Style {
-        Style::new()
-    }
-
     #[test]
     fn write_custom_target_less_than_limit() {
-        let mut buf = Vec::new();
-        let style = default_style();
-        write_target(&mut buf, &style, "my_crate").unwrap();
-        assert_eq!(String::from_utf8(buf).unwrap(), "my_crate: ");
+        assert_eq!(shorten_target("my_crate"), "my_crate");
     }
 
     #[test]
     fn write_custom_target_more_than_limit() {
-        let mut buf = Vec::new();
-        let style = default_style();
         let long_target = "my_very_long_crate_name_module_submodule";
-        write_target(&mut buf, &style, long_target).unwrap();
-        assert_eq!(String::from_utf8(buf).unwrap(), "my_very_long_crate_n: ");
+        assert_eq!(shorten_target(long_target), "my_very_long_crate_n");
     }
 
     #[test]
     fn write_module_target_less_than_limit() {
-        let mut buf = Vec::new();
-        let style = default_style();
-        write_target(&mut buf, &style, "my_limited_crate1234::module").unwrap();
-        assert_eq!(String::from_utf8(buf).unwrap(), "my_limited_crate1234: ");
+        assert_eq!(
+            shorten_target("my_limited_crate1234::module"),
+            "my_limited_crate1234"
+        );
     }
 
     #[test]
     fn write_module_target_more_than_limit() {
-        let mut buf = Vec::new();
-        let style = default_style();
         let long_target = "my_very_long_crate_name_module_submodule::submodule";
-        write_target(&mut buf, &style, long_target).unwrap();
-        assert_eq!(String::from_utf8(buf).unwrap(), "my_very_long_crate_n: ");
+        assert_eq!(shorten_target(long_target), "my_very_long_crate_n");
     }
 }

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -11,7 +11,9 @@
 //!
 //! Call [`init`] or [`init_with_config`] once per process, before anything logs.
 //! `RUST_LOG` overrides the [`Config`] filters and accepts the usual
-//! `target=level` syntax.
+//! `target=level` syntax. `FLOR_LOG_UNSANITIZED=1` lets escape sequences carried
+//! inside a message reach the terminal — colored error stacks at the cost of the
+//! terminal-injection defense; it is ignored unless stderr is a terminal.
 
 use std::borrow::Cow;
 use std::fmt;
@@ -168,17 +170,18 @@ pub fn init_with_config(config: &Config) -> Result<(), Report<Error>> {
 
     // `tracing-subscriber` rewrites escape sequences found *inside* a message, as
     // a terminal-injection defense — our messages carry peer-controlled text
-    // (hostnames, SPIFFE IDs, remote error strings), so a release build always
-    // keeps it. The cost is that a styled `Report` arrives mangled rather than
-    // colored, since its escapes travel inside the message.
+    // (hostnames, SPIFFE IDs, remote error strings). The cost is that a styled
+    // `Report` arrives mangled rather than colored, since its escapes travel
+    // inside the message.
     //
-    // Debug builds trade that away: a developer reading an error stack in a
-    // terminal benefits from the color, and the peers involved are their own. The
-    // relaxation is scoped as narrowly as it can be — debug build *and* a terminal
-    // sink — so a redirected dev log is still sanitized.
-    // Release's log is always sanitized.
-    let styled_reports = ansi && cfg!(debug_assertions);
-    Report::set_color_mode(if styled_reports {
+    // `FLOR_LOG_UNSANITIZED` trades that away for a developer running a reproducer
+    // in a controlled environment, where the peers involved are their own. It is a
+    // runtime choice rather than a build one, because the binary under debugging is
+    // often release-optimized. It is honored only on a terminal — the one sink with
+    // no storage behind it, so no durable log is poisoned — and announced below, so
+    // a relaxed process says so rather than being inferred.
+    let unsanitized = ansi && env_flag("FLOR_LOG_UNSANITIZED");
+    Report::set_color_mode(if unsanitized {
         error_stack::fmt::ColorMode::Color
     } else {
         error_stack::fmt::ColorMode::None
@@ -187,14 +190,27 @@ pub fn init_with_config(config: &Config) -> Result<(), Report<Error>> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
         .with_ansi(ansi)
-        .with_ansi_sanitization(!styled_reports)
+        .with_ansi_sanitization(!unsanitized)
         .event_format(format);
 
     tracing_subscriber::registry()
         .with(build_filter(config)?)
         .with(fmt_layer)
         .try_init()
-        .change_context(Error("Failed to set logger".into()))
+        .change_context(Error("Failed to set logger".into()))?;
+
+    if unsanitized {
+        tracing::warn!(
+            "Log sanitization disabled by FLOR_LOG_UNSANITIZED: messages may carry terminal escapes"
+        );
+    }
+
+    Ok(())
+}
+
+/// Reads an opt-in flag from the environment: set to anything but empty or `0`.
+fn env_flag(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
 /// Maps the `Config` filters onto an `EnvFilter`, with `RUST_LOG` taking precedence.

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -10,8 +10,8 @@
 //! handler carries that connection's identity without being passed it.
 //!
 //! Call [`init`] or [`init_with_config`] once per process, before anything logs.
-//! `RUST_LOG` overrides the [`Config`] filters and accepts the usual
-//! `target=level` syntax. `FLOR_LOG_UNSANITIZED=1` lets escape sequences carried
+//! `RUST_LOG` layers over the [`Config`] filters, in `tracing`'s directive
+//! syntax. `FLOR_LOG_UNSANITIZED=1` lets escape sequences carried
 //! inside a message reach the terminal — colored error stacks at the cost of the
 //! terminal-injection defense; it is ignored unless stderr is a terminal.
 
@@ -118,7 +118,11 @@ impl Default for Config {
 
 /// Initializes the global logger by default `Config` with global log filter.
 ///
-/// `RUST_LOG` environment variable can be used to override the log filter settings.
+/// `RUST_LOG` environment variable can be used to override the log filter
+/// settings; see [`init_with_config`] for how the two combine, and [`EnvFilter`
+/// directives][directives] for the syntax it accepts.
+///
+/// [directives]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 ///
 /// ### Arguments
 /// - `log_level`: sets global level filter of the logger
@@ -141,6 +145,16 @@ pub fn init(log_level: LevelFilter) -> Result<(), Report<Error>> {
 /// Priority of log filter settings in decending order:
 /// 1. `RUST_LOG` environment variable,
 /// 2. Custom filter settings from `Config` passed to this function.
+///
+/// The two compose rather than replace one another: `RUST_LOG` wins for the
+/// targets it names, and the `Config` filters still govern every other target.
+/// So `RUST_LOG=quinn=trace` raises that one component and leaves the rest where
+/// the `Config` put them. `RUST_LOG` accepts [`EnvFilter` directives][directives]
+/// — `target[span{field=value}]=level`, which is `env_logger`'s syntax extended
+/// with span and field selectors, and without its trailing `/regex` message
+/// filter.
+///
+/// [directives]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 ///
 /// ### Arguments
 /// - `config`: custom configuration for the logger
@@ -193,8 +207,9 @@ pub fn init_with_config(config: &Config) -> Result<(), Report<Error>> {
         .with_ansi_sanitization(!unsanitized)
         .event_format(format);
 
+    let rust_log = std::env::var("RUST_LOG").ok();
     tracing_subscriber::registry()
-        .with(build_filter(config)?)
+        .with(build_filter(config, rust_log.as_deref())?)
         .with(fmt_layer)
         .try_init()
         .change_context(Error("Failed to set logger".into()))?;
@@ -213,7 +228,14 @@ fn env_flag(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
-/// Maps the `Config` filters onto an `EnvFilter`, with `RUST_LOG` taking precedence.
+/// Maps the `Config` filters onto an `EnvFilter`, with `rust_log` — the value of
+/// `RUST_LOG` — layered on top of them.
+///
+/// The env directives are appended after the `Config` ones rather than replacing
+/// them, so that a component-only value such as `RUST_LOG=quinn=trace` raises that
+/// one component while everything else stays at the level the `Config` asked for.
+/// A directive naming the same target as an earlier one supersedes it, which is
+/// what makes `RUST_LOG` win where the two overlap.
 ///
 /// The two sources are parsed with deliberately different strictness. `RUST_LOG`
 /// is operator input typed at runtime, so an unusable directive is dropped with a
@@ -223,20 +245,24 @@ fn env_flag(name: &str) -> bool {
 ///
 /// On the other hand, `Config` directives are programmer input, so a malformed one
 /// is a bug and fails initialization instead of being skipped.
-fn build_filter(config: &Config) -> Result<tracing_subscriber::EnvFilter, Report<Error>> {
-    if let Ok(env) = std::env::var("RUST_LOG")
-        && !env.is_empty()
-    {
-        return Ok(tracing_subscriber::EnvFilter::new(env));
-    }
-
+fn build_filter(
+    config: &Config,
+    rust_log: Option<&str>,
+) -> Result<tracing_subscriber::EnvFilter, Report<Error>> {
     let mut directives = vec![config.global_log_filter.to_string()];
     for (module, level) in &config.modules_log_filter {
         directives.push(format!("{module}={level}"));
     }
     let directives = directives.join(",");
-    tracing_subscriber::EnvFilter::try_new(&directives)
-        .change_context_lazy(|| Error(format!("Invalid log filter directives: '{directives}'")))
+    let filter = tracing_subscriber::EnvFilter::try_new(&directives)
+        .change_context_lazy(|| Error(format!("Invalid log filter directives: '{directives}'")))?;
+
+    match rust_log {
+        Some(env) if !env.is_empty() => Ok(tracing_subscriber::EnvFilter::new(format!(
+            "{directives},{env}"
+        ))),
+        _ => Ok(filter),
+    }
 }
 
 /// Renders one event as `<time> <LEVEL> <component>: <spans> <message+fields>`.
@@ -389,5 +415,62 @@ mod tests {
     fn write_module_target_more_than_limit() {
         let long_target = "my_very_long_crate_name_module_submodule::submodule";
         assert_eq!(shorten_target(long_target), "my_very_long_crate_n");
+    }
+
+    fn directives_of(config: &Config, rust_log: Option<&str>) -> Vec<String> {
+        let mut directives: Vec<String> = build_filter(config, rust_log)
+            .expect("filter builds")
+            .to_string()
+            .split(',')
+            .map(str::to_owned)
+            .collect();
+        directives.sort();
+        directives
+    }
+
+    #[test]
+    fn config_filters_apply_without_env() {
+        let config = Config::new()
+            .global_log_filter(LevelFilter::INFO)
+            .module_log_filter("quinn".into(), LevelFilter::WARN);
+        assert_eq!(directives_of(&config, None), ["info", "quinn=warn"]);
+    }
+
+    /// A component-only `RUST_LOG` raises that component and leaves the global
+    /// level from `Config` in place, rather than silencing everything else.
+    #[test]
+    fn env_component_directive_keeps_config_global_level() {
+        let config = Config::new().global_log_filter(LevelFilter::INFO);
+        assert_eq!(
+            directives_of(&config, Some("quinn=trace")),
+            ["info", "quinn=trace"]
+        );
+    }
+
+    #[test]
+    fn env_supersedes_config_for_the_same_target() {
+        let config = Config::new()
+            .global_log_filter(LevelFilter::INFO)
+            .module_log_filter("quinn".into(), LevelFilter::WARN);
+        assert_eq!(
+            directives_of(&config, Some("debug,quinn=trace")),
+            ["debug", "quinn=trace"]
+        );
+    }
+
+    /// An unusable `RUST_LOG` directive is dropped, and the rest still applies.
+    #[test]
+    fn env_bad_directive_is_ignored() {
+        let config = Config::new().global_log_filter(LevelFilter::INFO);
+        assert_eq!(
+            directives_of(&config, Some("quinn=debgu,flor=debug")),
+            ["flor=debug", "info"]
+        );
+    }
+
+    #[test]
+    fn invalid_config_directive_fails_init() {
+        let config = Config::new().module_log_filter("quinn=".into(), LevelFilter::WARN);
+        assert!(build_filter(&config, None).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,8 @@ fn main() {
         Cmd::Vertex {
             action: VertexAction::Run(vertex_args),
         } => {
-            logging::logger::init(log::LevelFilter::Info).expect("Failed to initialize logger");
+            logging::logger::init(logging::logger::LevelFilter::INFO)
+                .expect("Failed to initialize logger");
             if let Err(e) = run_vertex(vertex_args) {
                 print_error(&e, verbose);
                 std::process::exit(1);

--- a/src/northbound/inbound/socks5.rs
+++ b/src/northbound/inbound/socks5.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::{JoinHandle, JoinSet};
+use tracing::Instrument;
 
 use crate::core::identity::{Dialable, X509Svid};
 use crate::core::transport::QuicConnector;
@@ -159,28 +160,34 @@ async fn bind_listeners(
 }
 
 async fn run_listener(caller: Arc<X509Svid>, listener: TcpListener, backend: Arc<dyn QuicBackend>) {
-    let principal = caller.spiffe_id().clone();
+    let initiator = caller.spiffe_id().clone();
     let mut tasks = JoinSet::new();
     loop {
         tokio::select! {
             result = listener.accept() => match result {
                 Ok((stream, peer_addr)) => {
-                    log::debug!(target: LOG_TARGET,
-                        "Accepted connection from {peer_addr} for principal '{principal}'");
+                    let span = tracing::error_span!(
+                        target: LOG_TARGET,
+                        "conn",
+                        initiator = %initiator,
+                        client_sock_addr = %peer_addr,
+                        target = tracing::field::Empty,
+                    );
                     let backend = backend.clone();
                     let caller = caller.clone();
-                    let principal = principal.clone();
-                    tasks.spawn(async move {
-                        if let Err(e) = handle_socks5(stream, backend, caller).await {
-                            log::warn!(target: LOG_TARGET,
-                                "Connection from {peer_addr} via SOCKS5 for principal \
-                                 '{principal}' error: {e:?}");
+                    tasks.spawn(
+                        async move {
+                            log::debug!(target: LOG_TARGET, "Accepted connection");
+                            if let Err(e) = handle_socks5(stream, backend, caller).await {
+                                log::warn!(target: LOG_TARGET, "SOCKS5 connection error: {e:?}");
+                            }
                         }
-                    });
+                        .instrument(span),
+                    );
                 }
                 Err(e) => {
                     log::error!(target: LOG_TARGET,
-                        "SOCKS5 listener for '{principal}' accept error: {e:?}");
+                        "SOCKS5 listener for '{initiator}' accept error: {e:?}");
                     break;
                 }
             },
@@ -231,12 +238,14 @@ async fn handle_socks5(
         }
     };
 
+    tracing::Span::current().record("target", tracing::field::display(&host));
+
     // Step 4: Resolve the hostname to a dial target against the caller's trust
     // domain (inbound builds services only; see ADR-0007).
     let target = match Dialable::resolve(&host, caller.spiffe_id().trust_domain()) {
         Ok(target) => target,
         Err(e) => {
-            log::debug!(target: LOG_TARGET, "Cannot resolve target '{host}': {e:?}");
+            tracing::debug!(target: LOG_TARGET, "Target unresolvable: {e}");
             proto
                 .reply_error(&ReplyError::HostUnreachable)
                 .change_context(Error("Failed to reply to unresolvable target".into()))


### PR DESCRIPTION
This is initial commit with single instrumentation site (socks5 inbound) that demonstrates new tracing capability.

Closes #67